### PR TITLE
Update en-us inherited section from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,6 @@ information.
 ## Installation
 
 ```shell
-npm install hyphenated
-```
-
-To install separately from hyphenated:
-
-```shell
 npm install hyphenated-ru
 ```
 


### PR DESCRIPTION
The removed section is inherited from [hyphenated-en-us](https://github.com/sergeysolovev/hyphenated/tree/master/packages/hyphenated-en-us) and is not relevant for the Russian language patterns as they don’t come included with the `hyphenated` package by default.